### PR TITLE
feat: determine historic tie probability

### DIFF
--- a/cli/boxscore.py
+++ b/cli/boxscore.py
@@ -308,3 +308,20 @@ def boxscore_frequency(args: argparse.Namespace) -> None:
             freq_obj[i] = 0
     with open("./data/preprocessed/frequency.json", 'w') as freq_file:
         freq_file.write(json.dumps(freq_obj, indent=4, sort_keys=True))
+
+def boxscore_tie_frequency(args: argparse.Namespace) -> None:
+    """
+    Execute the boxscore tie-frequency subcommand
+
+    Args:
+    args (argparse.Namespace): The CLI args
+
+    Returns:
+    None
+    """
+    score_df = pandas.read_json("./data/processed/training.json")
+    tie_df = score_df["home_score"] == score_df["away_score"]
+    tie_freq = tie_df.value_counts()
+    print(tie_freq)
+    print("\nExpected tie probability:")
+    print(tie_freq[True] / (tie_freq[True] + tie_freq[False]))

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -232,6 +232,12 @@ def set_boxscore_subcommand(
         "frequency",
         help="Get the frequency of historic box scores"
     )
+
+    # Initialize the frequency label subcommand parser
+    boxscore_tie_frequency_parser = boxscore_subparser.add_parser(
+        "tie-frequency",
+        help="Get the frequency of historic ties"
+    )
     return subparser
 
 def get_cli_args() -> Type[argparse.Namespace]:

--- a/main.py
+++ b/main.py
@@ -4,7 +4,8 @@ from cli.boxscore   import  list_boxscores, \
                             visualize_boxscores, \
                             label_boxscores, \
                             aggregate_boxscores, \
-                            boxscore_frequency
+                            boxscore_frequency, \
+                            boxscore_tie_frequency
 from cli.cli        import  get_cli_args
 from cli.labeled    import  get_skill_differential_score_summary, \
                             summarize_skill_differential_score_summary, \
@@ -36,6 +37,8 @@ def main(args: argparse.Namespace) -> None:
             aggregate_boxscores(args)
         elif args.subcommand == "frequency":
             boxscore_frequency(args)
+        elif args.subcommand == "tie-frequency":
+            boxscore_tie_frequency(args)
         else:
             raise Exception(
                 f"Unrecognized boxscore subcommand {args.subcommand}"


### PR DESCRIPTION
In this PR, I calculate the historic tie probability from my training data.  I also calculate the same probability from the test and validation data.  The test and validation data sets are relatively smaller data sets.  I think the true expected tie probability is `p_tie = 0.006`.

Training data:
```
False    10652
True        68
Name: count, dtype: int64

Expected tie probability:
0.006343283582089552
```

Test data:
```
False    1472
True        5
Name: count, dtype: int64

Expected tie probability:
0.003385240352064997
```

Validation data:
```
False    1361
True        9
Name: count, dtype: int64

Expected tie probability:
0.006569343065693431
```

For reference, see:
- https://github.com/whatsacomputertho/fbdb-boxscore-eda/issues/6